### PR TITLE
Added the ability to turn off the light when the surroundings get dark

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1276,6 +1276,18 @@ public:
 		}
 
 protected:
+	bool draw() override
+	{
+		screen_ascii_editor_t::draw();
+
+		int16_t ambient = get_ambient();
+		char buf[16];
+		sprintf_P(buf, PSTR("now:%4d"), ambient);
+		fb().draw_text(0, 35, 255, buf, font_5x5);
+
+		return true;
+	}
+
 	bool validate(const String &line) override
 	{
 		return line.toInt() < 1023;


### PR DESCRIPTION
照度センサで測定した周囲の明るさが暗い場合、LEDをオフする機能を追加します。(睡眠妨害防止用機能)

変更点
1.screen_other_setting画面を追加。screen_clockのときにBUTTON_LEFT押下で遷移できます。
→現状は1つしかありませんが、今後他の機能を追加するときのルート設定画面にしたい。

2.screen_light_off_threshold_editor画面を追加。
→照度センサの閾値を設定する画面です。

3.screen_clock画面で、照度センサの値が一定値以上(暗くなったとき)であればLEDをオフします。



